### PR TITLE
extract ticket id from ticket URL

### DIFF
--- a/resources/templates/estimate-view.html
+++ b/resources/templates/estimate-view.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 {% block body %}
 <form method="POST" action="/refine/{{refinement.code}}/ticket/{{ticket.id}}/estimate">
-  <p>We are estimating ticket <a href="{{ticket.original-link}}">{{ticket.id}}</a>
+  <p>We are estimating ticket <a href="{{ticket.link-to-original}}">{{ticket.id}}</a>
     <div>
       <button onclick="copy_estimation_link()">Copy link to estimation page</button>
     </div>

--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "templates/base.html" %}
 {% block body %}
 <form method="POST" action="/refine">
-  <p>HI! Please, write the id of the ticket to refine <input type="text" name="ticket-id" placeholder="Ticket id here"/> and <button name="start-session">Start!</button></p>
+  <p>HI! Please, write the URL of the ticket to refine <input type="text" name="ticket-url" placeholder="Ticket url here"/> and <button name="start-session">Start!</button></p>
 </form>
 {% endblock %}

--- a/src/clj/fpsd/configuration.clj
+++ b/src/clj/fpsd/configuration.clj
@@ -4,7 +4,4 @@
 
 (mount/defstate config
   :start {:http  {:port (:unrefined-http-port env 8080)}
-          :nrepl {:port (:unrefined-nrepl-port env 1337)}
-          :format-link-to-ticket (if-let [link (:unrefined-link-to-ticket env)]
-                                   (partial format link)
-                                   identity)})
+          :nrepl {:port (:unrefined-nrepl-port env 1337)}})

--- a/src/clj/fpsd/refinements.clj
+++ b/src/clj/fpsd/refinements.clj
@@ -84,13 +84,13 @@
    :skips #{}})
 
 (defn new-ticket
-  [ticket-id]
+  [ticket-id ticket-url]
   {:id ticket-id
    :status :unrefined
    :result nil
    :current-session (new-empty-session)
    :sessions []
-   :link-to-original ((:format-link-to-ticket config) ticket-id)})
+   :link-to-original ticket-url})
 
 (defn add-ticket!
   [code ticket]
@@ -98,8 +98,8 @@
   ticket)
 
 (defn add-new-ticket!
-  [code ticket-id]
-  (add-ticket! code (new-ticket ticket-id)))
+  [code ticket-id ticket-url]
+  (add-ticket! code (new-ticket ticket-id ticket-url)))
 
 (defn set-participant
   [code user-id name]


### PR DESCRIPTION
When creating refinements or adding tickets it is possible to provide
a URL to the ticket; the ticket id is extracted from the URL if
possible otherwise the whole string is used as the ticket id