### PR TITLE
Button to re estimate

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,11 @@
+# ROADMAP
+
+## Features of the MVP
+
+- Create a refinement session with at least a ticket to estimate
+- Share the link to the estimation page
+- Estimate a ticket, providing story points or skipping the estimation
+  - Write the breakdown of the provided story points
+- Show the result of the estimation
+  - TODO Provide a way to re-estimate a ticket
+- TODO Estimate a new ticket directly from the result or watch pages

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,5 +7,5 @@
 - Estimate a ticket, providing story points or skipping the estimation
   - Write the breakdown of the provided story points
 - Show the result of the estimation
-  - TODO Provide a way to re-estimate a ticket
+  - Provide a way to re-estimate a ticket
 - TODO Estimate a new ticket directly from the result or watch pages

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -16,3 +16,8 @@ body {
   padding: 8px;
   font-size: 30px;
 }
+
+button a {
+  text-decoration: none;
+  color: black;
+}

--- a/resources/public/main.js
+++ b/resources/public/main.js
@@ -29,12 +29,19 @@ function update_vote_stats(payload) {
   g_chart.draw(data, {title: 'Distribution of votes'});
 }
 
+function goto_estimation_page(code, ticket_id) {
+  document.location.href = '/refine/' + code + '/ticket/' + ticket_id + '/estimate';
+}
+
 function handle_sse_messages(e) {
   const data = JSON.parse(e.data);
   console.log(data);
 
   if( data.event == 'user-voted' || data.event == 'user-skipped' || data.event == 'ticket-status') {
     update_vote_stats(data.payload);
+  }
+  else if( data.event == 're-estimate-ticket' && document.location.href.includes('estimate')) {
+    goto_estimation_page(data.payload.code, data.payload.ticket_id);
   }
 }
 

--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -53,6 +53,11 @@
 	{% endfor %}
       </ul>
     </p>
+    <p>
+      <form method="POST" action="/refine/{{refinement.code}}/ticket/{{ticket.id}}/re-estimate">
+	<button>Re-estimate ticket</button>
+      </form>
+    </p>
   {% endifequal %}
   </div>
   <div style="width: 50%">

--- a/src/clj/fpsd/refinements.clj
+++ b/src/clj/fpsd/refinements.clj
@@ -173,15 +173,15 @@
    Returns the updated ticket."
   [ticket]
   (-> ticket
-      (update :sessions conj (:current-session ticket)
-      (assoc :current-session (new-empty-session))) )
+      (update :sessions conj (:current-session ticket))
+      (assoc :current-session (new-empty-session))))
 
 (defn send-re-estimate-event!
   "Send an event to signal that a new estimation for a ticket is starting"
   [code ticket-id]
   (send-event! code {:event :re-estimate-ticket
                      :payload {:code code
-                               :ticket-id ticket-id}}))
+                               :ticket_id ticket-id}}))
 
 (defn re-estimate-ticket
   "Updates the ticket to start a new estimation and send an event to clients"

--- a/src/clj/fpsd/refinements/handlers.clj
+++ b/src/clj/fpsd/refinements/handlers.clj
@@ -171,3 +171,11 @@
      :cookies {"user-id" {:value user-id :same-site :strict}
                "name" {:value name :same-site :strict}}
      :status 200}))
+
+(defn estimate-again
+  [request]
+  (let [code (-> request :path-params :code)
+        ticket-id (-> request :path-params :ticket-id)]
+    (refinements/re-estimate-ticket code ticket-id)
+    {:headers {:location (format "/refine/%s/ticket/%s" code ticket-id)}
+     :status 302}))

--- a/src/clj/fpsd/routes.clj
+++ b/src/clj/fpsd/routes.clj
@@ -48,6 +48,7 @@
 
       ["/:code/ticket/:ticket-id/estimate" {:get handlers/estimate-view
                                             :post handlers/estimate-done}]
+      ["/:code/ticket/:ticket-id/re-estimate" {:post handlers/estimate-again}]
       ["/:code/ticket/:ticket-id/events" {:get handlers/events-stream-handler}]
       ["/:code/ticket" {:post handlers/add-ticket}]
       ["/:code/events" {:get handlers/events-stream-handler}]]]


### PR DESCRIPTION
When estimating a ticket a new estimation session may be required.

After starting a new estimation all interested clients must be informed and a new estimation page must be shown.

Is it still not clear if watchers must be updated as well, but for the sake of the MVP we assume that notifying them can be implemented later.