### PR TITLE
Refine new ticket

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,4 +8,16 @@
   - Write the breakdown of the provided story points
 - Show the result of the estimation
   - Provide a way to re-estimate a ticket
-- TODO Estimate a new ticket directly from the result or watch pages
+- Estimate a new ticket directly from the result or watch pages
+
+## Ideas for future improvements
+
+- Friendly development environment especially to modify frontend code, ideas:
+  - Dockerfile that runs the server
+  - Alias in deps.edn to run the server
+- Change the estimation page to force the use of the breakdown form
+  - The total will be calculated summing the breakdowns
+  - It would be nice to be able to configure the breakdown items
+  - It would be nice to be able to enable breakdowns or the single estimation
+- Better design and UX
+- Persistent storage

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -14,7 +14,7 @@ body {
 
 .flex-container > div {
   padding: 8px;
-  font-size: 30px;
+  font-size: 24px;
 }
 
 button a {

--- a/resources/templates/estimate-done.html
+++ b/resources/templates/estimate-done.html
@@ -26,4 +26,5 @@
 </div>
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>
+<script type="text/javascript">start();</script>
 {% endblock %}

--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -77,4 +77,5 @@
 
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>
+<script type="text/javascript">start();</script>
 {% endblock %}

--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -60,9 +60,12 @@
     </p>
   {% endifequal %}
 
-   <form method="POST" action="/refine/{{refinement.code}}">
-     <input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Estimate new ticket</button>
-    </form>
+    <p>
+      Estimate a new ticket:
+      <form method="POST" action="/refine/{{refinement.code}}/ticket">
+	<input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Start!</button>
+      </form>
+    </p>
   </div>
   <div style="width: 50%">
     <p>Current activity</p>

--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -59,6 +59,10 @@
       </form>
     </p>
   {% endifequal %}
+
+   <form method="POST" action="/refine/{{refinement.code}}">
+     <input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Estimate new ticket</button>
+    </form>
   </div>
   <div style="width: 50%">
     <p>Current activity</p>

--- a/resources/templates/estimate-view.html
+++ b/resources/templates/estimate-view.html
@@ -25,4 +25,8 @@
     </div>
   </div>
 </form>
+
+<script type="text/javascript" src="/assets/sse.js"></script>
+<script type="text/javascript" src="/assets/main.js"></script>
+<script type="text/javascript">init_sse();</script>
 {% endblock %}

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -33,4 +33,5 @@
 
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>
+<script type="text/javascript">start();</script>
 {% endblock %}

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -15,6 +15,10 @@
       Reveal results
       </a>
     </button>
+
+    <form method="POST" action="/refine/{{refinement.code}}">
+      <input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Estimate new ticket</button>
+    </form>
   </div>
   <div style="width: 50%">
     <p>Current activity</p>

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -16,9 +16,12 @@
       </a>
     </button>
 
-    <form method="POST" action="/refine/{{refinement.code}}">
-      <input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Estimate new ticket</button>
-    </form>
+    <p>
+      Estimate a new ticket:
+      <form method="POST" action="/refine/{{refinement.code}}/ticket">
+	<input type="text" name="ticket-url" placeholder="Ticket URL here"/><button>Start!</button>
+      </form>
+    </p>
   </div>
   <div style="width: 50%">
     <p>Current activity</p>

--- a/src/clj/fpsd/refinements.clj
+++ b/src/clj/fpsd/refinements.clj
@@ -13,7 +13,6 @@
 (comment
   (identity @refinements_)
   (identity (get @refinements_ "OKCAVG"))
-  (identity (get @refinements_ "YEMJVQ" "asdf"))
   ,)
 
 (defn details
@@ -94,9 +93,17 @@
    :sessions []
    :link-to-original ticket-url})
 
+(defn send-ticket-added-event!
+  "Send an event to signal that a new ticket is being estimated"
+  [code ticket-id]
+  (send-event! code {:event :added-ticket
+                     :payload {:code code
+                               :ticket_id ticket-id}}))
+
 (defn add-ticket!
   [code ticket]
   (swap! refinements_ update-in [code :tickets] assoc (:id ticket) ticket)
+  (send-ticket-added-event! code (:id ticket))
   ticket)
 
 (defn add-new-ticket!

--- a/src/clj/fpsd/refinements/handlers.clj
+++ b/src/clj/fpsd/refinements/handlers.clj
@@ -64,7 +64,7 @@
         ticket-url (-> request :params :ticket-url)
         ticket-id (extract-ticket-id-from-url ticket-url)]
 
-    (refinements/add-new-ticket! code ticket-id)
+    (refinements/add-new-ticket! code ticket-id ticket-url)
     {:headers {:location (format "/refine/%s/ticket/%s" code ticket-id)}
      :status 302}))
 


### PR DESCRIPTION
After estimating a ticket it might be needed to estimate a new ticket, but it would be nice to not go back to the home page to start a new refinement session.

The idea is to provide a form in the watch and result page to start estimating a new ticket.