### PR TITLE
do not provide an estimate result if not enough votes

### DIFF
--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -10,6 +10,10 @@
       <div><button onclick="copy_estimation_link('/estimate')">Copy link to estimation page</button></div>
     </p>
 
+  {% ifequal estimation.result :not-enough-votes %}
+    <p>Unfortunately we havent reached the minimum number of votes ({{settings.reasonable-minimum-votes}}).</p>
+    <p>You may want to estimate a new ticket or wait for more votes.</p>
+  {% endifequal %}
   {% ifequal estimation.result :winner %}
     <p>Ticket estimated with a score of <strong>{{estimation.points}}</strong></p>
     <p>Points and voters

--- a/src/clj/fpsd/estimator.clj
+++ b/src/clj/fpsd/estimator.clj
@@ -49,19 +49,22 @@
 
 (defn estimate
   [{:keys [current-session sessions] :as _ticket} settings]
-  (let [votes (-> current-session :votes count-votes)
-        delta (votes-delta votes)
-        result
-        (if (or (< delta (:max-points-delta settings))
-                (max-rediscussions-reached sessions settings))
-          (select-winner votes)
+  (if (> (:reasonable-minimum-votes settings)
+         (-> current-session :votes count))
+      {:result :not-enough-votes}
+      (let [votes (-> current-session :votes count-votes)
+            delta (votes-delta votes)
+            result
+            (if (or (< delta (:max-points-delta settings))
+                    (max-rediscussions-reached sessions settings))
+              (select-winner votes)
 
-          (let [{lowest-vote :points lowest-voters :authors} (last votes)
-                {highest-vote :points highest-voters :authors} (first votes)]
-            {:result :discuss
-             :highest-vote highest-vote
-             :highest-voters highest-voters
-             :lowest-vote lowest-vote
-             :lowest-voters lowest-voters}))]
-    (-> result
-        (assoc :votes votes))))
+              (let [{lowest-vote :points lowest-voters :authors} (last votes)
+                    {highest-vote :points highest-voters :authors} (first votes)]
+                {:result :discuss
+                 :highest-vote highest-vote
+                 :highest-voters highest-voters
+                 :lowest-vote lowest-vote
+                 :lowest-voters lowest-voters}))]
+        (-> result
+            (assoc :votes votes)))))

--- a/src/clj/fpsd/refinements.clj
+++ b/src/clj/fpsd/refinements.clj
@@ -2,7 +2,7 @@
   (:require [fpsd.estimator :as estimator]))
 
 (def default-settings {:max-points-delta 3
-                       :voting-style :linear ;; or :fibonacci
+                       :reasonable-minimum-votes 3
                        :max-rediscussions 1
                        :suggestion-strategy :majority})
 

--- a/test/fpsd/estimator_test.clj
+++ b/test/fpsd/estimator_test.clj
@@ -1,7 +1,8 @@
 (ns fpsd.estimator-test
     (:require
      [clojure.test :refer [deftest is testing]]
-     [fpsd.estimator :as estimator]))
+     [fpsd.estimator :as estimator]
+     [fpsd.refinements :as refinements]))
 
 (testing "Estimator utils"
   (deftest count-votes
@@ -69,8 +70,7 @@
                "id5" {:points 3 :name "Foo"}
                "id6" {:points 3 :name "Bar"}}}
              :sessions []}
-            {:max-rediscussions 1
-             :max-points-delta 3}))))
+            refinements/default-settings))))
 
   (deftest ex-æquo-case
     (is (= {:result :ex-equo
@@ -85,8 +85,7 @@
                                        "3" {:points 2 :name "Joe"}
                                        "4" {:points 3 :name "Foo"}}}
              :sessions []}
-            {:max-rediscussions 1
-             :max-points-delta 3}))))
+            refinements/default-settings))))
 
   (deftest discuss-case
     (is (= {:result :discuss
@@ -104,8 +103,7 @@
                                        "3" {:points 4 :name "Joe"}
                                        "4" {:points 3 :name "Foo"}}}
              :sessions []}
-            {:max-rediscussions 1
-             :max-points-delta 3}))))
+            refinements/default-settings))))
 
   (deftest select-most-voted-after-discussion-case
     (is (= {:result :winner
@@ -122,5 +120,10 @@
                                  "2" {:points 2 :name "Alice"}
                                  "3" {:points 4 :name "Joe"}
                                  "4" {:points 3 :name "Foo"}}}]}
-            {:max-rediscussions 1
-             :max-points-delta 3})))))
+            refinements/default-settings))))
+
+  (deftest not-enough-voters
+    (is (= {:result :not-enough-votes}
+           (estimator/estimate
+            {:current-session {:votes {"1" {:points 2 :name "Foo"}}}}
+            refinements/default-settings)))))


### PR DESCRIPTION
it can happen that many skip voting, or that there is not enough people at the refinement session. I guess a good
default minimum voters is 3...