### PR TITLE
#17 enable parsing trello URLs to extract ticket description

### DIFF
--- a/src/clj/fpsd/refinements/helpers.clj
+++ b/src/clj/fpsd/refinements/helpers.clj
@@ -1,13 +1,17 @@
-(ns fpsd.refinements.helpers)
+(ns fpsd.refinements.helpers
+  (:require [clojure.string :as str]))
 
-(def url-regexes [#"https://.*/issues/(.*)" #"https://.*/browse/(.*)"])
+(def url-parsers [[#"https://.*/issues/(.*)" second]
+                  [#"https://.*/browse/(.*)" second]
+                  [#"https://trello.com/c/\w+/\d+-(.*)" (fn [match] (-> match second (str/replace #"-" " ")))]])
 
 (defn extract-ticket-id-from-url
   "Return the ticket id extracted from the URL of the ticketing system,
    if the format is not recognized then return nil"
   [url]
   (when url
-    (some #(second (re-matches % url)) url-regexes)))
+    (some (fn [[regex transform-fn]] (some->> url (re-matches regex) transform-fn))
+          url-parsers)))
 
 (defn try-parse-int
   "Return the integer value represented by the string int-str

--- a/test/fpsd/refinements/helpers_test.clj
+++ b/test/fpsd/refinements/helpers_test.clj
@@ -10,6 +10,10 @@
   (deftest extract-github-id
     (is (= "12" (helpers/extract-ticket-id-from-url "https://github.com/fpischedda/unrefined/issues/12"))))
 
+  (deftest extract-trello-id
+    (is (= "parse trellos card url to extract description and id"
+           (helpers/extract-ticket-id-from-url "https://trello.com/c/xAaL7xNa/3-parse-trellos-card-url-to-extract-description-and-id"))))
+
   (deftest extract-id-fails
     (is (nil? (helpers/extract-ticket-id-from-url "https://some-garbage")))))
 


### PR DESCRIPTION
a bit of refactoring was required but tests have covered the changes quite well