### PR TITLE
Embed ticket info in refinements pages

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -25,3 +25,14 @@ button a {
   text-decoration: none;
   color: black;
 }
+
+.preview-container {
+  display: flex;
+  background-color: #cbe1ef;
+}
+
+.preview-container > div {
+  padding: 8px;
+  font-size: 24px;
+  background-color: #fafafa;
+}

--- a/resources/public/main.js
+++ b/resources/public/main.js
@@ -103,3 +103,13 @@ function start_voting_page() {
 
   init_sse();
 }
+
+function load_ticket_preview(refinement_code, ticket_id) {
+
+  var = url '/refinements/' + refinement_code + '/ticket/' + ticket_id + '/preview';
+  fetch(url)
+    .then(response => { response.text()})
+    .then(preview => {
+      document.getElementById('ticket-preview').innerHTML = preview
+  });
+}

--- a/resources/public/main.js
+++ b/resources/public/main.js
@@ -106,10 +106,14 @@ function start_voting_page() {
 
 function load_ticket_preview(refinement_code, ticket_id) {
 
-  var = url '/refinements/' + refinement_code + '/ticket/' + ticket_id + '/preview';
+  const url = '/refine/' + refinement_code + '/ticket/' + ticket_id + '/preview';
+  console.log('feching preview from ', url);
+
   fetch(url)
-    .then(response => { response.text()})
+    .then(response => { return response.text()})
     .then(preview => {
+      console.log('preview:');
+      console.log(preview);
       document.getElementById('ticket-preview').innerHTML = preview
-  });
+    });
 }

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -35,5 +35,5 @@
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>
 <script type="text/javascript">start();</script>
-<script type="text/javascript">load_ticket_preview('{{refinement.code}}', '{{ticket.id}}');</script>
+<!--><script type="text/javascript">load_ticket_preview('{{refinement.code}}', '{{ticket.id}}');</script></!-->
 {% endblock %}

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -29,8 +29,8 @@
     <p>Total skipped: <span id="total-skipped">{{ticket.current-session.skips|count}}</span></p>
     <div id="vote-chart"></div>
   </div>
-  <div id="ticket-preview" style="width: 100%"></div>
 </div>
+<div id="ticket-preview" class="preview-container"></div>
 
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -29,9 +29,11 @@
     <p>Total skipped: <span id="total-skipped">{{ticket.current-session.skips|count}}</span></p>
     <div id="vote-chart"></div>
   </div>
+  <div id="ticket-preview" style="width: 100%"></div>
 </div>
 
 <script type="text/javascript" src="/assets/sse.js"></script>
 <script type="text/javascript" src="/assets/main.js"></script>
 <script type="text/javascript">start();</script>
+<script type="text/javascript">load_ticket_preview('{{refinement.code}}', '{{ticket.id}}');</script>
 {% endblock %}

--- a/resources/templates/ticket-preview.html
+++ b/resources/templates/ticket-preview.html
@@ -1,0 +1,2 @@
+<div><a href={{url}}>{{summary}}</a></div>
+<div>{{description}}</div>

--- a/resources/templates/ticket-preview.html
+++ b/resources/templates/ticket-preview.html
@@ -1,2 +1,6 @@
-<div><a href={{url}}>{{summary}}</a></div>
-<div>{{description}}</div>
+<div>
+  <p><strong>Summary</strong></p>
+  <a href={{url}}>{{summary}}</a>
+  <p><strong>Description</strong></p>
+  {{description|safe}}
+</div>

--- a/src/clj/fpsd/refinements/core.clj
+++ b/src/clj/fpsd/refinements/core.clj
@@ -2,7 +2,8 @@
   (:require [fpsd.refinements.events :as events]
             [fpsd.refinements :as refinements]
             [fpsd.refinements.helpers :refer [utc-now] :as helpers]
-            [fpsd.unrefined.state :as state]))
+            [fpsd.unrefined.state :as state]
+            [fpsd.unrefined.ticket-parser :refer [fetch-jira-ticket]]))
 
 
 (defn get-refinement
@@ -102,3 +103,12 @@
 
   (events/send-re-estimate-event! (state/get-refinement-sink code)
                                   code ticket-id))
+
+(defn ticket-preview
+  [code ticket-id]
+  (state/transact! update-in [:refinements code :tickets ticket-id]
+                   (fn [ticekt]
+                     (if-not (:preview ticket)
+                       (assoc ticket :preview (delay (fetch-jira-ticket ticket-id)))
+                       ticket)))
+  (:preview (get-ticket code ticket-id)))

--- a/src/clj/fpsd/refinements/core.clj
+++ b/src/clj/fpsd/refinements/core.clj
@@ -107,7 +107,7 @@
 (defn ticket-preview
   [code ticket-id]
   (state/transact! update-in [:refinements code :tickets ticket-id]
-                   (fn [ticekt]
+                   (fn [ticket]
                      (if-not (:preview ticket)
                        (assoc ticket :preview (delay (fetch-jira-ticket ticket-id)))
                        ticket)))

--- a/src/clj/fpsd/refinements/handlers.clj
+++ b/src/clj/fpsd/refinements/handlers.clj
@@ -130,3 +130,11 @@
 
     {:headers {:location (safe-ticket-url code ticket-id)}
      :status 302}))
+
+(defn ticket-preview
+  [request]
+  (let [{:keys [code ticket-id]} (:path-params request)
+        preview-future (core/get-ticket-preview code ticket-id)]
+
+    {:body (render-file "templates/ticket-preview.html" @preview-future)
+     :status 200}))

--- a/src/clj/fpsd/refinements/handlers.clj
+++ b/src/clj/fpsd/refinements/handlers.clj
@@ -134,7 +134,7 @@
 (defn ticket-preview
   [request]
   (let [{:keys [code ticket-id]} (:path-params request)
-        preview-future (core/get-ticket-preview code ticket-id)]
+        preview-future (core/ticket-preview code ticket-id)]
 
     {:body (render-file "templates/ticket-preview.html" @preview-future)
      :status 200}))

--- a/src/clj/fpsd/routes.clj
+++ b/src/clj/fpsd/routes.clj
@@ -50,7 +50,8 @@
          ["/estimate" {:get handlers/estimate-view
                        :post handlers/estimate-done}]
          ["/re-estimate" {:post handlers/estimate-again}]
-         ["/events" {:get handlers/events-stream-handler}]]]
+         ["/events" {:get handlers/events-stream-handler}]
+         ["/preview" {:get handlers/ticket-preview}]]]
 
        ["events" {:get handlers/events-stream-handler}]]]]
 

--- a/src/clj/fpsd/routes.clj
+++ b/src/clj/fpsd/routes.clj
@@ -6,6 +6,7 @@
             [aleph.http :as http]
             [mount.core :as mount]
             [ring.middleware.cookies :refer [wrap-cookies]]
+            [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.session :refer [wrap-session]]
             [fpsd.configuration :refer [config]]
@@ -58,6 +59,7 @@
     {:data {:muuntaja m/instance
             :middleware [muuntaja/format-middleware
                          wrap-cookies
+                         wrap-params
                          wrap-keyword-params
                          common-cookies]}})))
 

--- a/src/clj/fpsd/unrefined/ticket_parser.clj
+++ b/src/clj/fpsd/unrefined/ticket_parser.clj
@@ -2,9 +2,14 @@
   (:require [cheshire.core :refer [parse-string]]
             [org.httpkit.client :as http]))
 
+(defn ticket-url->rest-url
+  [ticket-url]
+  (let [[_ host ticket-id] (re-matches #"https://(.*)/browse/(.*)" ticket-url)]
+    (format "https://%s/rest/api/latest/issue/%s?expand=renderedFields" host ticket-id)))
+
 (defn fetch-jira-ticket-data
   [ticket-url]
-  (-> ticket-url (http/get {:as :text}) deref :body parse-string))
+  (-> ticket-url ticket-url->rest-url (http/get {:as :text}) deref :body parse-string))
 
 (defn parse-jira-ticket-data
   [data]
@@ -18,6 +23,8 @@
   (-> ticket-url fetch-jira-ticket-data parse-jira-ticket-data))
 
 (comment
+  (ticket-url->rest-url  "https://jira.atlassian.com/browse/JRA-9")
+  ;; => "https://jira.atlassian.com/rest/api/latest/issue/JRA-9?expand=renderedFields"
   ;; trying with a ticket provided in JIRA's docs
   (fetch-jira-ticket "https://jira.atlassian.com/rest/api/latest/issue/JRA-9?expand=renderedFields")
   ,)


### PR DESCRIPTION
preliminary work to load ticket info from JIRA API and render it (brutally...) inside the watch page; it works with public Jira instances, no auth provided (yet).