### PR TITLE
dispatch storage calls based on configurable backends

### DIFF
--- a/src/clj/fpsd/configuration.clj
+++ b/src/clj/fpsd/configuration.clj
@@ -7,5 +7,6 @@
           :nrepl {:port (:unrefined-nrepl-port env 1667)}
           :logging {:type :simple-file
                     :filename (:unrefined-log-file env "/tmp/unrefined.log")}
-          :persistence {:path (:unrefined-tickets-path env "/tmp/")}
+          :persistence {:backend :json-file
+                        :path (:unrefined-tickets-path env "/tmp/")}
           :mr-clean {:ttl (:unrefined-refinement-ttl env (* 60 60 12))}})

--- a/src/clj/fpsd/refinements/core.clj
+++ b/src/clj/fpsd/refinements/core.clj
@@ -113,9 +113,13 @@
     (cond
       (nil? refinement) (format "Unable to find refinement %s" code)
       (nil? ticket) (format "Unable to find ticket %s in refinement %s" ticket-id code)
-      :else (persistence/store-ticket-to-file! refinement
-                                               ticket
-                                               (estimator/estimate ticket (:settings refinement))))))
+      :else
+      (persistence/store-ticket!
+       code
+       ticket-id
+       {:refinement (dissoc refinement :tickets)
+        :ticket ticket
+        :estimation (estimator/estimate ticket (:settings refinement))}))))
 
 (defn get-stored-ticket
   [code ticket-id]

--- a/src/clj/fpsd/unrefined/persistence.clj
+++ b/src/clj/fpsd/unrefined/persistence.clj
@@ -1,28 +1,18 @@
 (ns fpsd.unrefined.persistence
-  (:require [cheshire.core :as json]
-            [cheshire.generate :refer [add-encoder encode-str]]
-            [fpsd.configuration :refer [config]]))
+  (:require [fpsd.configuration :refer [config]]))
 
-(add-encoder java.time.LocalDateTime encode-str)
+(defmulti store-ticket-backend!
+  (fn [configuration _code _ticket-id _data] (:backend configuration)))
 
-(defn get-ticket-path
-  "Return the full path to the ticket data store"
-  [code ticket-id]
-  (format "%s/%s-%s.json" (-> config :persistence :path) code ticket-id))
+(defmulti get-ticket-backend
+  (fn [configuration _code _ticket-id] (:backend configuration)))
 
-(defn store-ticket-to-file!
-  "Store the ticket and refinement data to file"
-  [refinement ticket estimation]
-  (let [filename (get-ticket-path (:code refinement) (:id ticket))
-        contents (json/generate-string {:refinement (dissoc refinement :tickets)
-                                        :ticket ticket
-                                        :estimation estimation})]
-    (spit filename contents)))
+(defn store-ticket!
+  "Store the ticket and refinement data according to the selected backend"
+  [code ticket-id data]
+  (store-ticket-backend! (:persistence config) code ticket-id data))
 
 (defn get-stored-ticket
   "Read the content of the ticket from file and returns it"
   [code ticket-id]
-  (-> (get-ticket-path code ticket-id)
-      slurp
-      (json/parse-string true)
-      (update-in [:estimation :result] keyword)))
+  (get-ticket-backend (:persistence config) code ticket-id))

--- a/src/clj/fpsd/unrefined/persistence/json_file.clj
+++ b/src/clj/fpsd/unrefined/persistence/json_file.clj
@@ -1,0 +1,24 @@
+(ns fpsd.unrefined.persistence
+  (:require [cheshire.core :as json]
+            [cheshire.generate :refer [add-encoder encode-str]]
+            [fpsd.unrefined.persistence :refer [store-ticket-backend! get-ticket-backend]]))
+
+(add-encoder java.time.LocalDateTime encode-str)
+
+(defn get-ticket-path
+  "Return the full path to the ticket data store"
+  [configuration code ticket-id]
+  (format "%s/%s-%s.json" (:path configuration) code ticket-id))
+
+(defmethod store-ticket-backend! :json-file
+  [configuration code ticket-id data]
+  (let [filename (get-ticket-path configuration code ticket-id)
+        contents (json/generate-string data)]
+    (spit filename contents)))
+
+(defmethod get-ticket-backend :json-file
+  [configuration code ticket-id]
+  (-> (get-ticket-path configuration code ticket-id)
+      slurp
+      (json/parse-string true)
+      (update-in [:estimation :result] keyword)))


### PR DESCRIPTION
store-ticket! and get-stored-ticket now dospatch to multimethods in order to be able to plug different storage engines without changing the caller side.

Now :json-file storage write data to disk as json, in future it would be trivial to add support for SQL databases, s3 like object stores etc