### PR TITLE
enable re-estimation again, also in watch page

### DIFF
--- a/resources/templates/estimate-results.html
+++ b/resources/templates/estimate-results.html
@@ -11,6 +11,14 @@
       {% include "templates/estimation-result-fragment.html" with estimation=estimation refinement=refinement %}
 
       <p>
+	<form method="POST" action="/refine/{{refinement.code}}/ticket/{{ticket.id}}/re-estimate">
+	  <button class="btn btn-primary">
+	    Re-estimate ticket
+	  </button>
+	</form>
+      </p>
+
+      <p>
 	<h5>Estimate a new ticket</h5>
 	<form method="POST" action="/refine/{{refinement.code}}/ticket">
 	  <input class="form-control"

--- a/resources/templates/estimate-watch.html
+++ b/resources/templates/estimate-watch.html
@@ -8,9 +8,19 @@
         <div><button type="button" class="btn btn-primary" onclick="copy_estimation_link('{{refinement.code}}', '{{ticket.id}}')">Copy link to estimation page</button></div>
       </p>
 
+      <p>
         <a class="btn btn-primary" href="/refine/{{refinement.code}}/ticket/{{ticket.id}}/results">
           Reveal results
         </a>
+      </p>
+
+      <p>
+	<form method="POST" action="/refine/{{refinement.code}}/ticket/{{ticket.id}}/re-estimate">
+	  <button class="btn btn-primary">
+	    Reset current estimation
+	  </button>
+	</form>
+      </p>
 
       <p>
         Estimate a new ticket:


### PR DESCRIPTION
It was already possible to re-estimate tickets but somehow the button has been removed.

This MR also add the re-estimation button to the watch page; the label says Reset current estimation because feel better in this context.

Solves #28 