### PR TITLE
Add estimation breakdown and utilities to migrate the schema 

### DIFF
--- a/resources/templates/estimate-done.html
+++ b/resources/templates/estimate-done.html
@@ -4,13 +4,13 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <p>Hi {{vote.name}}!<br/>Thank you for estimating the ticket {{ticket.id}}.</p>
-      {% if vote.skipped? %}
+      <p>Hi {{estimation.author-name}}!<br/>Thank you for estimating the ticket {{ticket.id}}.</p>
+      {% if estimation.skipped? %}
       <p>You <strong>skipped</strong>.</p>
       {% else %}
-      <p>Your vote: <strong>{{vote.points}}</strong></p>
+      <p>Your vote: <strong>{{estimation.points}}</strong></p>
       <p>Breakdown:
-        <ul>{% for item in vote.breakdown %}
+        <ul>{% for item in estimation.breakdown %}
     <li>{{item|first|name}}: {{item|last}}</li>
     {% endfor %}
         </ul>

--- a/src/clj/fpsd/refinements.clj
+++ b/src/clj/fpsd/refinements.clj
@@ -1,6 +1,5 @@
 (ns fpsd.refinements
-  (:require [fpsd.estimator :as estimator]
-            [fpsd.refinements.helpers :refer [utc-now]]))
+  (:require [fpsd.refinements.helpers :refer [utc-now]]))
 
 (def default-settings {:max-points-delta 3
                        :minimum-votes 3

--- a/src/clj/fpsd/refinements/core.clj
+++ b/src/clj/fpsd/refinements/core.clj
@@ -89,18 +89,18 @@
 
     ticket))
 
-(defn vote-ticket
-  [{:keys [code ticket-id session-num author-id author-name vote] :as _estimation}]
+(defn estimate-ticket
+  [{:keys [code ticket-id session-num author-id author-name estimation] :as _estimation}]
 
   (state/add-estimation code ticket-id session-num
                         {:author-id author-id
                          :author-name author-name
-                         :score (:points vote)
-                         :skipped? (boolean (:skipped? vote))
-                         :breakdown (:breakdown vote)})
+                         :score (:points estimation)
+                         :skipped? (boolean (:skipped? estimation))
+                         :breakdown (:breakdown estimation)})
 
   (events/send-vote-event! code
-                           (if (:skipped? vote) :user-skipped :user-voted)
+                           (if (:skipped? estimation) :user-skipped :user-voted)
                            author-id
                            (state/get-ticket code ticket-id)))
 

--- a/src/clj/fpsd/refinements/core.clj
+++ b/src/clj/fpsd/refinements/core.clj
@@ -95,8 +95,9 @@
   (state/add-estimation code ticket-id session-num
                         {:author-id author-id
                          :author-name author-name
-                         :score (long (:points vote))
-                         :skipped? (boolean (:skipped? vote))})
+                         :score (:points vote)
+                         :skipped? (boolean (:skipped? vote))
+                         :breakdown (:breakdown vote)})
 
   (events/send-vote-event! code
                            (if (:skipped? vote) :user-skipped :user-voted)

--- a/src/clj/fpsd/refinements/helpers.clj
+++ b/src/clj/fpsd/refinements/helpers.clj
@@ -38,14 +38,14 @@
   [params supported-breakdowns]
   (reduce (fn [acc breakdown]
              (if-let [value (get params breakdown)]
-               (assoc acc (name breakdown) (try-parse-long value 0))
+               (assoc acc breakdown (try-parse-long value 0))
                acc))
            {} supported-breakdowns))
 
-(defn get-vote-from-params
+(defn get-estimation-from-params
   [params]
   {:points (-> params :points (try-parse-long 0))
-   :name (or (params :name) "Anonymous Coward")
+   :author-name (or (params :name) "Anonymous Coward")
    :skipped? (some? (:skip-button params))
    :breakdown (get-breakdown-from-params params initial-supported-breakdowns_)})
 

--- a/src/clj/fpsd/refinements/helpers.clj
+++ b/src/clj/fpsd/refinements/helpers.clj
@@ -31,10 +31,11 @@
    (try (Long/parseLong str-value)
         (catch NumberFormatException _ default))))
 
-(def supported-breakdowns [:implementation :backend :migrations :data_migrations :testing :manual_testing :risk :complexity])
+(def initial-supported-breakdowns_
+  [:implementation :backend :migrations :data_migrations :testing :manual_testing :risk :complexity])
 
 (defn get-breakdown-from-params
-  [params]
+  [params supported-breakdowns]
   (reduce (fn [acc breakdown]
              (if-let [value (get params breakdown)]
                (assoc acc breakdown (try-parse-long value 0))
@@ -46,7 +47,7 @@
   {:points (-> params :points (try-parse-long 0))
    :name (or (params :name) "Anonymous Coward")
    :skipped? (some? (:skip-button params))
-   :breakdown (get-breakdown-from-params params)})
+   :breakdown (get-breakdown-from-params params initial-supported-breakdowns_)})
 
 (defn utc-now
   []

--- a/src/clj/fpsd/refinements/helpers.clj
+++ b/src/clj/fpsd/refinements/helpers.clj
@@ -15,20 +15,38 @@
 
 (defn try-parse-int
   "Return the integer value represented by the string int-str
-   or nil if it is not possible to parse the number"
-  [int-str]
-  (try (Integer/parseInt int-str)
-       (catch NumberFormatException _ nil)))
+   or default if it is not possible to parse the number"
+  ([str-value]
+   (try-parse-int str-value nil))
+  ([str-value default]
+   (try (Integer/parseInt str-value)
+        (catch NumberFormatException _ default))))
+
+(defn try-parse-long
+  "Return the integer value represented by the string int-str
+   or default if it is not possible to parse the number"
+  ([str-value]
+   (try-parse-long str-value nil))
+  ([str-value default]
+   (try (Long/parseLong str-value)
+        (catch NumberFormatException _ default))))
 
 (def supported-breakdowns [:implementation :backend :migrations :data_migrations :testing :manual_testing :risk :complexity])
 
+(defn get-breakdown-from-params
+  [params]
+  (reduce (fn [acc breakdown]
+             (if-let [value (get params breakdown)]
+               (assoc acc breakdown (try-parse-long value 0))
+               acc))
+           {} supported-breakdowns))
+
 (defn get-vote-from-params
   [params]
-  {:points (-> params :points try-parse-int (or 0))
-   :name (or (-> params :name) "Anonymous Coward")
+  {:points (-> params :points (try-parse-long 0))
+   :name (or (params :name) "Anonymous Coward")
    :skipped? (some? (:skip-button params))
-   :breakdown
-   (select-keys params supported-breakdowns)})
+   :breakdown (get-breakdown-from-params params)})
 
 (defn utc-now
   []

--- a/src/clj/fpsd/refinements/helpers.clj
+++ b/src/clj/fpsd/refinements/helpers.clj
@@ -38,7 +38,7 @@
   [params supported-breakdowns]
   (reduce (fn [acc breakdown]
              (if-let [value (get params breakdown)]
-               (assoc acc breakdown (try-parse-long value 0))
+               (assoc acc (name breakdown) (try-parse-long value 0))
                acc))
            {} supported-breakdowns))
 

--- a/src/clj/fpsd/unrefined/persistence/datahike.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike.clj
@@ -13,7 +13,7 @@
   "Try to apply migrations and log errors if any."
   [db migrations]
   (let [{:migration/keys [error applied not-applied]}
-        (migrator/collect-migrations-to-apply db migrations)]
+        (migrator/collect-migrations-to-apply @db migrations)]
     (if error
       (u/log ::migrate-schema
              :errors error
@@ -126,12 +126,12 @@
   ;; trying the migrator manually :)
   (d/transact db migrator/migrations-schema)
 
-  (migrator/get-applied-migrations db)
+  (migrator/get-applied-migrations @db)
   
   (migrator/analyze-migrations (concat migrator/initial-migration schema/migrations)
-                               (migrator/get-applied-migrations db))
+                               (migrator/get-applied-migrations @db))
 
-  (migrator/collect-migrations-to-apply db schema/migrations)
+  (migrator/collect-migrations-to-apply @db schema/migrations)
   
   (migrate-schema! db schema/migrations)
   ,)

--- a/src/clj/fpsd/unrefined/persistence/datahike.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike.clj
@@ -131,7 +131,7 @@
   (migrator/analyze-migrations (concat migrator/initial-migration schema/migrations)
                                (migrator/get-applied-migrations @db))
 
-  (migrator/collect-migrations-to-apply @db schema/migrations)
+  (migrator/collect-migrations-to-apply @db (concat migrator/initial-migration schema/migrations))
   
   (migrate-schema! db schema/migrations)
   ,)

--- a/src/clj/fpsd/unrefined/persistence/datahike/migrator.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike/migrator.clj
@@ -41,13 +41,14 @@
     migration))
 
 (defn get-applied-migrations
+  "Return a vector with all previously applied migrations,
+   sorted by :migration/applied-at."
   [db]
   (->> db
        (d/q '[:find (pull ?e [*])
                :where [?e :migration/name]
                       [?e :migration/applied-at]
-                      [?e :migration/transactions]]
-                @db)
+                      [?e :migration/transactions]])
        flatten
        (sort-by :migration/applied-at)))
 

--- a/src/clj/fpsd/unrefined/persistence/datahike/migrator.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike/migrator.clj
@@ -1,0 +1,86 @@
+(ns fpsd.unrefined.persistence.datahike.migrator
+ "Utilities to apply schema changes to an existing database.
+  So far only accretive changes are supported.
+
+  The idea is to keep a list of applied migrations, compare it
+  to what the application expects and run transactions with changes
+  not yet applied to the db.
+
+  At the same time we want to be sure that migrations recorded in the
+  database are in sink with what the application axpects.
+
+  Assume that the applications expects to have migrations a, b, c:
+  - in the database we have recorded only a and c (missing migration)
+  - in the database we have recorded a, c, b (out of order migrations)
+  - in the database we have recorded a, b, b2, c (out of sync app, not covered yet)."
+ (:require [datahike.api :as d]
+           [fpsd.refinements.helpers :refer [utc-now]]))
+
+(def migrations-schema
+  [{:db/ident :migration/name
+    :db/unique :db.unique/identity
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :migration/applied-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :migration/transactions
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(def initial-migration
+  [{:migration/name "Initial migrator schema migration"
+    :migration/transactions migrations-schema}])
+
+(defn apply-migration
+  [db name transactions]
+  (let [migration {:migration/name name
+                   :migration/applied-at (utc-now)
+                   :migration/transactions (pr-str transactions)}]
+    (d/transact db (conj transactions migration))
+    migration))
+
+(defn get-applied-migrations
+  [db]
+  (->> db
+       (d/q '[:find (pull ?e [*])
+               :where [?e :migration/name]
+                      [?e :migration/applied-at]
+                      [?e :migration/transactions]]
+                @db)
+       flatten
+       (sort-by :migration/applied-at)))
+
+(defn analyze-migrations
+  "Return a vector of expected migrations compared to the current
+   status recorded in the database (applied). Each element have a status
+   according to previous state: :not-applied, :applied, :error."
+  [expected applied]
+  (let [applied-map
+        (->> applied
+             (map-indexed (fn [idx a] [(:migration/name a) (assoc a :migration/index idx)]))
+             (into {}))]
+
+    (->> expected
+         (map-indexed
+          (fn [idx e]
+            (let [applied (get applied-map (:migration/name e))]
+              (cond
+                (nil? applied) (assoc e :migration/status :migration/not-applied)
+                (= idx (:migration/index applied)) (assoc e :migration/status :migration/applied)
+                :else
+                (assoc e
+                       :migration/status :migration/error
+                       :migration/error (format "Out of order migration, expected index %s, found %s"
+                                                idx (:migration/index applied)))))))
+         (into []))))
+
+(defn collect-migrations-to-apply
+  "Return a map with migrations gruped by theirs status,
+   :migration/applied, :migration/not-applied, :migration/error.
+   The caller is expected to handle errors or apply not applied migrations"
+  [db migrations]
+  (->> db
+       get-applied-migrations
+       (analyze-migrations migrations)
+       (group-by :migration/status)))

--- a/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
@@ -158,3 +158,7 @@
           estimation-session-schema
           estimation-schema
           estimation-breakdown-schema))
+
+(def migrations
+  [{:migration/name "add estimation breakdown"
+    :migration/transactions estimation-breakdown-schema}])

--- a/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
@@ -133,6 +133,17 @@
     :db/cardinality :db.cardinality/one}
    {:db/ident :estimation/skipped?
     :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :estimation/breakdown
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many}])
+
+(def estimation-breakdown-schema
+  [{:db/ident :estimation-breakdown/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :estimation-breakdown/points
+    :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one}])
 
 (defn full-schema
@@ -145,4 +156,5 @@
           estimation-session-status-enum-schema
           estimation-session-result-enum-schema
           estimation-session-schema
-          estimation-schema))
+          estimation-schema
+          estimation-breakdown-schema))

--- a/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
+++ b/src/clj/fpsd/unrefined/persistence/datahike/schema.clj
@@ -144,7 +144,10 @@
     :db/cardinality :db.cardinality/one}
    {:db/ident :estimation-breakdown/points
     :db/valueType :db.type/long
-    :db/cardinality :db.cardinality/one}])
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :estimation/breakdown
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many}])
 
 (defn full-schema
   []

--- a/src/clj/fpsd/unrefined/state.clj
+++ b/src/clj/fpsd/unrefined/state.clj
@@ -92,8 +92,7 @@
 
 (defn db->estimation-breakdown
   [{:estimation-breakdown/keys [name points]}]
-  {:name (keyword name)
-   :points points})
+  {(keyword name) points})
 
 (defn db->estimation
   [{:estimation/keys [author-id author-name score skipped? breakdown] :as estimation}]
@@ -102,7 +101,7 @@
    :author-name author-name
    :score score
    :skipped? skipped?
-   :breakdown (mapv db->estimation-breakdown breakdown)})
+   :breakdown (->> breakdown (mapv db->estimation-breakdown) (into {}))})
 
 (defn db->session
   [{:estimation-session/keys [num votes status result] :as session}]
@@ -178,6 +177,6 @@
                    :estimation/author-name author-name
                    :estimation/score score
                    :estimation/skipped? skipped?
-                   :estimation/breakdown (for [[name points] breakdown]
-                                {:estimation-breakdown/name name
-                                 :estimation-breakdown/points points})}])))
+                   :estimation/breakdown (for [[kw-name points] breakdown]
+                                           {:estimation-breakdown/name (name kw-name)
+                                            :estimation-breakdown/points points})}])))

--- a/src/clj/fpsd/unrefined/state.clj
+++ b/src/clj/fpsd/unrefined/state.clj
@@ -98,13 +98,19 @@
                     [:refinement/id code])]
     (db->refinement res)))
 
+(defn db->estimation-breakdown
+  [{:estimation-breakdown/keys [name points]}]
+  {:name name
+   :points points})
+
 (defn db->estimation
-  [{:estimation/keys [author-id author-name score skipped?] :as estimation}]
+  [{:estimation/keys [author-id author-name score skipped? breakdown] :as estimation}]
   {:db/id (:db/id estimation)
    :author-id author-id
    :author-name author-name
    :score score
-   :skipped? skipped?})
+   :skipped? skipped?
+   :breakdown (mapv db->estimation-breakdown breakdown)})
 
 (defn db->session
   [{:estimation-session/keys [num votes status result] :as session}]
@@ -144,7 +150,8 @@
                     '[* {:refinement/_tickets [* {:refinement/voting-mode [:db/ident]
                                                   :refinement/settings [*]}]
                          :ticket/sessions [* {:estimation-session/status [:db/ident]
-                                              :estimation-session/votes [*]}]}]
+                                              :estimation-session/votes [* {:estimation/breakdown [:estimation-breakdown/name
+                                                                                                   :estimation-breakdown/points]}]}]}]
                     [:ticket/refinement+id [code ticket-id]])]
     {:refinement (db->refinement (-> res :refinement/_tickets first))
      :ticket (db->ticket res)}))
@@ -170,12 +177,20 @@
 
 (defn add-estimation
   [refinement ticket-id session-num
-   {:keys [author-id author-name score skipped?] :as _estimation}]
-   (let [session-id [:estimation-session/refinement+ticket+num [refinement ticket-id session-num]]]
-     (d/transact db
+   {:keys [author-id author-name score skipped? breakdown] :as _estimation}]
+  (let [session-id [:estimation-session/refinement+ticket+num [refinement ticket-id session-num]]
+        estimation-id (d/tempid)
+        estimation-breakdowns (for [[name points] breakdown]
+                                {:estimation/_breakdown estimation-id
+                                 :estimation-breakdown/name name
+                                 :estimation-breakdown/points points})]
+    (d/transact db
+                (concat
                  [{:estimation-session/_votes session-id
+                   :db/id estimation-id
                    :estimation/session session-id
                    :estimation/author-id author-id
                    :estimation/author-name author-name
                    :estimation/score score
-                   :estimation/skipped? skipped?}])))
+                   :estimation/skipped? skipped?}]
+                 estimation-breakdowns))))

--- a/test/fpsd/refinements/helpers_test.clj
+++ b/test/fpsd/refinements/helpers_test.clj
@@ -52,15 +52,15 @@
     (is (= {:available 1} (helpers/get-breakdown-from-params {:available "1"
                                                               :not-available "2"} [:available])))))
 
-(testing "get-vote-from-params extract vote, name and breakdown from request body"
+(testing "get-estimation-from-params extract vote, name and breakdown from request body"
   (deftest all-defaults-when-empty-params
     (are [params expected]
-         (= (helpers/get-vote-from-params params) expected)
+         (= (helpers/get-estimation-from-params params) expected)
 
       ;; all defaults on empty params
       {}
       {:points 0
-       :name "Anonymous Coward"
+       :author-name "Anonymous Coward"
        :breakdown {}
        :skipped? false}
 
@@ -69,7 +69,7 @@
        :testing "1"
        :backend "2"}
       {:points 0
-       :name "Bob"
+       :author-name "Bob"
        :breakdown {:testing 1
                    :backend 2}
        :skipped? false}
@@ -80,7 +80,7 @@
        :testing "1"
        :backend "2"}
       {:points 3
-       :name "Bob"
+       :author-name "Bob"
        :breakdown {:testing 1
                    :backend 2}
        :skipped? false}
@@ -88,7 +88,7 @@
       ;; skipping
       {:name "Skipper"
        :skip-button 1}
-      {:name "Skipper"
+      {:author-name "Skipper"
        :points 0
        :breakdown {}
        :skipped? true}

--- a/test/fpsd/refinements/helpers_test.clj
+++ b/test/fpsd/refinements/helpers_test.clj
@@ -41,6 +41,17 @@
   (deftest try-parse-long-uses-default
     (is (= 0 (helpers/try-parse-long "five" 0)))))
 
+(testing "get-breakdown-from-params"
+  (deftest skip-missing-breakdown
+    (is (= {} (helpers/get-breakdown-from-params {:new-one "1"} [:missing]))))
+
+  (deftest use-default-if-breakdown-empty-string
+    (is (= {:item 0} (helpers/get-breakdown-from-params {:item ""} [:item]))))
+
+  (deftest only-selects-available-breakdown
+    (is (= {:available 1} (helpers/get-breakdown-from-params {:available "1"
+                                                              :not-available "2"} [:available])))))
+
 (testing "get-vote-from-params extract vote, name and breakdown from request body"
   (deftest all-defaults-when-empty-params
     (are [params expected]

--- a/test/fpsd/refinements/helpers_test.clj
+++ b/test/fpsd/refinements/helpers_test.clj
@@ -21,12 +21,25 @@
       ;; failed
       "https://some-garbage" nil)))
 
-(testing "try-parse-int tries to convert a string to int, if it falis return nil"
+(testing "try-parse-int tries to convert a string to int, if it falis return nil or default"
   (deftest try-parse-int-success
     (is (= 5 (helpers/try-parse-int "5"))))
 
   (deftest try-parse-int-fail
-    (is (nil? (helpers/try-parse-int "five")))))
+    (is (nil? (helpers/try-parse-int "five"))))
+  
+  (deftest try-parse-int-uses-default
+    (is (= 0 (helpers/try-parse-int "five" 0)))))
+
+(testing "try-parse-long tries to convert a string to long, if it falis return nil or default"
+  (deftest try-parse-long-success
+    (is (= 5 (helpers/try-parse-long "5"))))
+
+  (deftest try-parse-long-fail
+    (is (nil? (helpers/try-parse-long "five"))))
+  
+  (deftest try-parse-long-uses-default
+    (is (= 0 (helpers/try-parse-long "five" 0)))))
 
 (testing "get-vote-from-params extract vote, name and breakdown from request body"
   (deftest all-defaults-when-empty-params
@@ -46,8 +59,8 @@
        :backend "2"}
       {:points 0
        :name "Bob"
-       :breakdown {:testing "1"
-                   :backend "2"}
+       :breakdown {:testing 1
+                   :backend 2}
        :skipped? false}
 
       ;; parse all
@@ -57,8 +70,8 @@
        :backend "2"}
       {:points 3
        :name "Bob"
-       :breakdown {:testing "1"
-                   :backend "2"}
+       :breakdown {:testing 1
+                   :backend 2}
        :skipped? false}
 
       ;; skipping

--- a/test/fpsd/unrefined/persistence/datahike/migrator_test.clj
+++ b/test/fpsd/unrefined/persistence/datahike/migrator_test.clj
@@ -1,0 +1,47 @@
+(ns fpsd.unrefined.persistence.datahike.migrator-test
+    (:require
+     [clojure.test :refer [deftest is testing]]
+     [fpsd.refinements.helpers :refer [utc-now]]
+     [fpsd.unrefined.persistence.datahike.migrator :as migrator]))
+
+(def migrations
+  [{:migration/name "test-01"
+    :migrations/transaction [{:db/ident :some/ident}]}])
+
+(def none-applied
+  [])
+
+(def all-applied
+  [{:migration/name "test-01"
+    :migration/applied-at (utc-now)
+    :migrations/transaction "[{:db/ident :some/ident}]"}])
+
+(def out-of-order
+  [{:migration/name "test-00"
+    :migration/applied-at (utc-now)
+    :migrations/transaction "[{:db/ident :some/ident}]"}
+   {:migration/name "test-01"
+    :migration/applied-at (utc-now)
+    :migrations/transaction "[{:db/ident :some/ident}]"}])
+
+(deftest analyze-migrations
+  (testing "Migration to be applied"
+    (is (= (-> (migrator/analyze-migrations migrations none-applied)
+               first
+               :migration/status)
+           :migration/not-applied)))
+
+  (testing "Migration alredy applied"
+    (is (= (-> (migrator/analyze-migrations migrations all-applied)
+               first
+               :migration/status)
+           :migration/applied)))
+
+  (testing "Migration out of order"
+    (is (= (-> (migrator/analyze-migrations migrations out-of-order)
+               first
+               (select-keys [:migration/status :migration/error]))
+           {:migration/status :migration/error
+            :migration/error "Out of order migration, expected index 0, found 1"})))
+
+  )


### PR DESCRIPTION
This branch started to address the creation of generic cheatsheet (which may still be addressed) bu later focused more on:
- add the estimation breakdown schema and store breakdowns received from frontend
- add schema migration tools in order to easily apply schema changes at application startup